### PR TITLE
Logging, mafft executable path, and pickle path fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `-v,--verbose` flag to control logging
+- Ability to specify the MAFFT binary [[#1][1]]
+
+### Changed
+
+- Logging switched to `loguru` [[#7][7]]
+
+### Fixed
+
+- Use the parent path of the update data structure to locate pickle objects
+
 ## [0.2.0] - 2021-05-07
 
 ### Changed
@@ -56,3 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.1.1]: https://github.com/rmcolq/make_prg/releases/v0.1.1
 [0.1.0]: https://github.com/rmcolq/make_prg/releases/v0.1.0
+
+[1]: https://github.com/leoisl/make_prg/issues/1
+[7]: https://github.com/leoisl/make_prg/issues/7

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ In this binary, all libraries are linked statically.
 
 * **Download**:
   ```
-  wget https://github.com/leoisl/make_prg/releases/download/v0.2.0/make_prg_0.2.0
+  wget https://github.com/leoisl/make_prg/releases/download/v0.3.0/make_prg_0.3.0
   ```
 * **Running**:
 ```
-chmod +x make_prg_0.2.0
-./make_prg_0.2.0 -h
+chmod +x make_prg_0.3.0
+./make_prg_0.3.0 -h
 ```
 
 * **Credits**:
@@ -105,13 +105,14 @@ optional arguments:
                         Maximum number of levels to use for nesting. Default: 5
   --min_match_length MIN_MATCH_LENGTH
                         Minimum number of consecutive characters which must be identical for a match. Default: 7
+  -v, --verbose         Increase output verbosity
 ```
 
 #### `update`
 
 ```
 $ make_prg update --help
-usage: make_prg update_prg
+usage: make_prg update
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -123,7 +124,9 @@ optional arguments:
                         Output prefix: prefix for the output files
   -t THREADS, --threads THREADS
                         Number of threads
+  --mafft MAFFT         Path to MAFFT executable. By default, it is assumed to be on PATH
   --keep_temp           Keep temp files.
+  -v, --verbose         Increase output verbosity
 ```
 
 [pandora]: https://github.com/rmcolq/pandora

--- a/make_prg/__init__.py
+++ b/make_prg/__init__.py
@@ -4,6 +4,6 @@ from pkg_resources import get_distribution
 try:
     __version__ = get_distribution("make_prg").version
 except:
-    __version__ = "0.2.0"
+    __version__ = "0.3.0"
 
 __all__ = ["from_msa", "subcommands", "io_utils", "seq_utils"]

--- a/make_prg/__main__.py
+++ b/make_prg/__main__.py
@@ -1,4 +1,7 @@
 import argparse
+import sys
+
+from loguru import logger
 
 from make_prg import __version__
 from make_prg.subcommands import from_msa, update
@@ -16,10 +19,25 @@ def main():
         title="Available subcommands", help="", metavar=""
     )
 
-    from_msa.register_parser(subparsers)
-    update.register_parser(subparsers)
+    msa_parser = from_msa.register_parser(subparsers)
+    update_parser = update.register_parser(subparsers)
+
+    for par in [msa_parser, update_parser]:
+        par.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            default=False,
+            help="Increase output verbosity",
+        )
 
     args = parser.parse_args()
+
+    log_lvl = "DEBUG" if args.verbose else "INFO"
+    handlers = [
+        dict(sink=sys.stderr, enqueue=True, level=log_lvl),
+    ]
+    logger.configure(handlers=handlers)
 
     if hasattr(args, "func"):
         args.func(args)

--- a/make_prg/from_msa/cluster_sequences.py
+++ b/make_prg/from_msa/cluster_sequences.py
@@ -140,7 +140,8 @@ def merge_clusters(clusters: List[ClusteredIDs], first_id: str) -> ClusteredIDs:
 
 
 def kmeans_cluster_seqs_in_interval(
-    alignment: MSA, kmer_size: int,
+    alignment: MSA,
+    kmer_size: int,
 ) -> ClusteredIDs:
     # Find unique sequences for clustering, but keep each sequence's IDs
     seq_to_ids: SeqToIDs = defaultdict(list)

--- a/make_prg/from_msa/interval_partition.py
+++ b/make_prg/from_msa/interval_partition.py
@@ -88,7 +88,9 @@ class IntervalPartitioner:
             if any(map(is_non_match, consensus_string)):
                 it_type = IntervalType.NonMatch
 
-            consensus_string_is_empty = len(consensus_string) == 0  # happens when the alignment is just gaps
+            consensus_string_is_empty = (
+                len(consensus_string) == 0
+            )  # happens when the alignment is just gaps
             if not consensus_string_is_empty:
                 self._append(Interval(it_type, 0, len(consensus_string) - 1))
         else:

--- a/make_prg/io_utils.py
+++ b/make_prg/io_utils.py
@@ -5,9 +5,10 @@ import fileinput
 from Bio import AlignIO
 import os
 
+from loguru import logger
+
 from make_prg.from_msa import MSA
 from make_prg.prg_encoder import PrgEncoder, PRG_Ints
-from make_prg.utils import print_with_time
 
 
 def load_alignment_file(msa_file: str, alignment_format: str) -> MSA:
@@ -63,13 +64,13 @@ class GFA_Output:
 
     def build_gfa_string(self, prg_string, pre_var_id=None):
         """Takes prg_string and builds a gfa_string with fragments
-           from the prg_string."""
+        from the prg_string."""
         end_ids = []
         # iterate through sites present, updating gfa_string with each in turn
         while str(self.gfa_site) in prg_string:
-            print_with_time("gfa_site: %d", self.gfa_site)
+            logger.trace("gfa_site: {}", self.gfa_site)
             prgs = self.split_on_site(prg_string, self.gfa_site)
-            print_with_time("prgs: %s", prgs)
+            logger.trace("prgs: {}", prgs)
             assert len(prgs) == 3, "Invalid prg sequence %s for site %d and id %d" % (
                 prg_string,
                 self.gfa_site,
@@ -96,9 +97,9 @@ class GFA_Output:
                 self.gfa_site + 1,
                 self.gfa_id,
             )
-            print_with_time("vars: %s", vars)
+            logger.trace("vars: {}", vars)
             self.gfa_site += 2
-            print_with_time("gfa_site: %d", self.gfa_site)
+            logger.trace("gfa_site: {}", self.gfa_site)
             for var_string in vars:
                 if pre_var_id != None:
                     self.gfa_string += "L\t%d\t+\t%d\t+\t0M\n" % (
@@ -164,12 +165,11 @@ def write_prg(output_prefix: str, prg_string: str):
     #     prg_encoder.write(prg_ints, ostream)
 
 
-
 def concatenate_text_files(input_filepaths, output_filepath):
     output_filepath_parent_dir = Path(output_filepath).parent
     os.makedirs(output_filepath_parent_dir, exist_ok=True)
 
-    with open(output_filepath, 'w') as fout:
+    with open(output_filepath, "w") as fout:
         empty_input = len(input_filepaths) == 0
         if empty_input:
             return

--- a/make_prg/prg_builder.py
+++ b/make_prg/prg_builder.py
@@ -446,7 +446,7 @@ class PrgBuilder(object):
         alignment_format,
         max_nesting,
         min_match_length,
-        mafft: str,
+        mafft: str = "",
     ):
         self.locus_name = locus_name
         self.msa_file = msa_file

--- a/make_prg/prg_builder.py
+++ b/make_prg/prg_builder.py
@@ -1,5 +1,7 @@
 from typing import List, Tuple
 
+from loguru import logger
+
 from make_prg.from_msa import MSA
 from make_prg.io_utils import load_alignment_file
 from make_prg.from_msa.cluster_sequences import kmeans_cluster_seqs_in_interval
@@ -9,7 +11,11 @@ from make_prg.seq_utils import (
     get_interval_seqs,
     NONMATCH,
 )
-from make_prg.from_msa.interval_partition import IntervalPartitioner, Interval, IntervalType
+from make_prg.from_msa.interval_partition import (
+    IntervalPartitioner,
+    Interval,
+    IntervalType,
+)
 import pickle
 from pathlib import Path
 import os
@@ -23,7 +29,6 @@ import subprocess
 import copy
 import numpy as np
 from Bio.Seq import Seq
-from make_prg.utils import print_with_time
 
 
 MATCH_SCORE = 2
@@ -35,17 +40,32 @@ GAP_EXTEND_SCORE = -2
 class MSAAligner(ABC):
     @classmethod
     @abstractmethod
-    def get_updated_alignment(cls, leaf_name: str, previous_alignment: Path, new_sequences: List[str], temp_prefix: Path) -> Path:
+    def get_updated_alignment(
+        cls,
+        leaf_name: str,
+        previous_alignment: Path,
+        new_sequences: List[str],
+        temp_prefix: Path,
+    ) -> Path:
         pass
 
 
 class MSAAlignerMAFFT(MSAAligner):
     @classmethod
-    def get_updated_alignment(cls, leaf_name: str, previous_alignment: Path, new_sequences: List[str], temp_prefix: Path) -> Path:
+    def get_updated_alignment(
+        cls,
+        leaf_name: str,
+        previous_alignment: Path,
+        new_sequences: List[str],
+        temp_prefix: Path,
+    ) -> Path:
         new_sequences_filename = temp_prefix / "new_sequences.fa"
         with open(new_sequences_filename, "w") as new_sequences_handler:
             for index_new_seq, new_seq in enumerate(new_sequences):
-                print(f">Denovo_path_{index_new_seq}_random_id_{uuid.uuid4()}", file=new_sequences_handler)
+                print(
+                    f">Denovo_path_{index_new_seq}_random_id_{uuid.uuid4()}",
+                    file=new_sequences_handler,
+                )
                 print(new_seq, file=new_sequences_handler)
 
         new_msa = temp_prefix / "updated_msa.fa"
@@ -74,7 +94,11 @@ class MSAAlignerMAFFT(MSAAligner):
 
         start = time.time()
         process = subprocess.Popen(
-            args, stderr=subprocess.PIPE, encoding="utf-8", shell=True, env=env,
+            args,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            shell=True,
+            env=env,
         )
         exit_code = process.wait()
         shutil.rmtree(mafft_tmpdir)
@@ -84,18 +108,14 @@ class MSAAlignerMAFFT(MSAAligner):
                 f"{process.stderr.read()}"
             )
         stop = time.time()
-        runtime = stop-start
-        print_with_time(f"MAFFT update runtime for {leaf_name} in seconds: {runtime:.3f}")
+        runtime = stop - start
+        logger.debug(f"MAFFT update runtime for {leaf_name} in seconds: {runtime:.3f}")
 
         return new_msa
 
 
 class PrgBuilderRecursiveTreeNode(ABC):
-    def __init__(self,
-                 nesting_level,
-                 alignment,
-                 parent,
-                 prg_builder):
+    def __init__(self, nesting_level, alignment, parent, prg_builder):
         # set the basic attributes
         self.id = prg_builder.get_next_node_id()
         self.nesting_level = nesting_level
@@ -152,17 +172,8 @@ class PrgBuilderRecursiveTreeNode(ABC):
 
 
 class PrgBuilderMultiClusterNode(PrgBuilderRecursiveTreeNode):
-    def __init__(self,
-                 nesting_level,
-                 alignment,
-                 parent,
-                 prg_builder):
-        super().__init__(
-            nesting_level,
-            alignment,
-            parent,
-            prg_builder
-        )
+    def __init__(self, nesting_level, alignment, parent, prg_builder):
+        super().__init__(nesting_level, alignment, parent, prg_builder)
 
     def _set_derived_helper_attributes(self):
         pass  # nothing to set here
@@ -176,7 +187,7 @@ class PrgBuilderMultiClusterNode(PrgBuilderRecursiveTreeNode):
                 nesting_level=self.nesting_level,
                 alignment=alignment,
                 parent=self,
-                prg_builder=self.prg_builder
+                prg_builder=self.prg_builder,
             )
             children.append(child)
         return children
@@ -188,11 +199,15 @@ class PrgBuilderMultiClusterNode(PrgBuilderRecursiveTreeNode):
         prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
 
         for child_index, child in enumerate(self._children):
-            site_num_to_separate_alleles = (site_num + 1) if (child_index < len(self._children) - 1) else site_num
+            site_num_to_separate_alleles = (
+                (site_num + 1) if (child_index < len(self._children) - 1) else site_num
+            )
             child.preorder_traversal_to_build_prg(prg_as_list, delim_char)
-            prg_as_list.extend(f"{delim_char}{site_num_to_separate_alleles}{delim_char}")
-    ##################################################################################
+            prg_as_list.extend(
+                f"{delim_char}{site_num_to_separate_alleles}{delim_char}"
+            )
 
+    ##################################################################################
 
     #####################################################################################################
     #  Clustering methods
@@ -201,15 +216,16 @@ class PrgBuilderMultiClusterNode(PrgBuilderRecursiveTreeNode):
             self.alignment,
             self.prg_builder.min_match_length,
         )
-        list_sub_alignments = [self._get_sub_alignment_by_list_id(id_list) for id_list in id_lists]
+        list_sub_alignments = [
+            self._get_sub_alignment_by_list_id(id_list) for id_list in id_lists
+        ]
         return list_sub_alignments
 
-    def _get_sub_alignment_by_list_id(
-        self, id_list: List[str]
-    ):
+    def _get_sub_alignment_by_list_id(self, id_list: List[str]):
         list_records = [record for record in self.alignment if record.id in id_list]
         sub_alignment = MSA(list_records)
         return sub_alignment
+
     #####################################################################################################
 
     def batch_update(self, temp_prefix):
@@ -217,17 +233,8 @@ class PrgBuilderMultiClusterNode(PrgBuilderRecursiveTreeNode):
 
 
 class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
-    def __init__(self,
-                 nesting_level,
-                 alignment,
-                 parent,
-                 prg_builder):
-        super().__init__(
-            nesting_level,
-            alignment,
-            parent,
-            prg_builder
-        )
+    def __init__(self, nesting_level, alignment, parent, prg_builder):
+        super().__init__(nesting_level, alignment, parent, prg_builder)
 
     def _set_derived_helper_attributes(self):
         self.consensus = self._get_consensus()
@@ -242,15 +249,19 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
 
     def _get_children(self):
         # stop conditions
-        single_match_interval = (len(self.all_intervals) == 1) and (self.all_intervals[0] in self.match_intervals)
+        single_match_interval = (len(self.all_intervals) == 1) and (
+            self.all_intervals[0] in self.match_intervals
+        )
         max_nesting_level_reached = self.nesting_level == self.prg_builder.max_nesting
-        small_variant_site = self.alignment.get_alignment_length() < self.prg_builder.min_match_length
+        small_variant_site = (
+            self.alignment.get_alignment_length() < self.prg_builder.min_match_length
+        )
         if single_match_interval or max_nesting_level_reached or small_variant_site:
             return list()
 
         children = []
         for interval in self.all_intervals:
-            sub_alignment = self.alignment[:, interval.start: interval.stop + 1]
+            sub_alignment = self.alignment[:, interval.start : interval.stop + 1]
 
             if interval in self.match_intervals:
                 # all seqs are not necessarily exactly the same: some can have 'N'
@@ -265,12 +276,11 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
                 nesting_level=self.nesting_level + 1,
                 alignment=sub_alignment,
                 parent=self,
-                prg_builder=self.prg_builder
+                prg_builder=self.prg_builder,
             )
             children.append(child)
 
         return children
-
 
     ##################################################################################
     # properties
@@ -284,8 +294,8 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
     @property
     def num_seqs(self):
         return len(self.alignment)
-    ##################################################################################
 
+    ##################################################################################
 
     ##################################################################################
     # traversal methods
@@ -296,12 +306,13 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
         else:
             for child in self._children:
                 child.preorder_traversal_to_build_prg(prg_as_list, delim_char)
+
     ##################################################################################
 
     ##################################################################################
     # helpers
     def _get_consensus(self):
-        """ Produces a 'consensus string' from an MSA: at each position of the
+        """Produces a 'consensus string' from an MSA: at each position of the
         MSA, the string has a base if all aligned sequences agree, and a "*" if not.
         IUPAC ambiguous bases result in non-consensus and are later expanded in the prg.
         N results in consensus at that position unless they are all N."""
@@ -309,10 +320,7 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
         for i in range(self.alignment.get_alignment_length()):
             column = set([record.seq[i] for record in self.alignment])
             column = column.difference({"N"})
-            if (
-                len(ambiguous_bases.intersection(column)) > 0
-                or len(column) != 1
-            ):
+            if len(ambiguous_bases.intersection(column)) > 0 or len(column) != 1:
                 consensus_string += NONMATCH
             else:
                 consensus_string += column.pop()
@@ -327,19 +335,26 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
             if single_seq:
                 start_index = len(prg_as_list)
                 prg_as_list.extend(seqs[0])
-                end_index = len(prg_as_list)+1
+                end_index = len(prg_as_list) + 1
                 self.prg_builder.update_leaves_index(start_index, end_index, node=self)
             else:
                 # Add the variant seqs to the prg.
                 site_num = self.prg_builder.get_next_site_num()
                 prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
                 for seq_index, seq in enumerate(seqs):
-                    site_num_for_this_seq = (site_num + 1) if (seq_index < len(seqs) - 1) else site_num
+                    site_num_for_this_seq = (
+                        (site_num + 1) if (seq_index < len(seqs) - 1) else site_num
+                    )
                     start_index = len(prg_as_list)
                     prg_as_list.extend(seq)
                     end_index = len(prg_as_list) + 1
-                    self.prg_builder.update_leaves_index(start_index, end_index, node=self)
-                    prg_as_list.extend(f"{delim_char}{site_num_for_this_seq}{delim_char}")
+                    self.prg_builder.update_leaves_index(
+                        start_index, end_index, node=self
+                    )
+                    prg_as_list.extend(
+                        f"{delim_char}{site_num_for_this_seq}{delim_char}"
+                    )
+
     ##################################################################################
 
     ##################################################################################
@@ -349,13 +364,13 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
             self.new_sequences = set()
         self.new_sequences.add(new_sequence)
 
-
     def batch_update(self, temp_prefix):
-        no_update_to_be_done = self.new_sequences is None or len(self.new_sequences) == 0
+        no_update_to_be_done = (
+            self.new_sequences is None or len(self.new_sequences) == 0
+        )
         if no_update_to_be_done:
             return
         self._update_leaf(temp_prefix)
-
 
     def _update_leaf(self, temp_prefix):
         # update the MSA
@@ -366,12 +381,16 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
         with open(previous_msa_filename, "w") as previous_msa_handler:
             SeqIO.write(self.alignment, previous_msa_handler, "fasta")
 
-        print_with_time(f"Updating MSA for {self.prg_builder.locus_name}, node {self.id}...")
+        logger.debug(
+            f"Updating MSA for {self.prg_builder.locus_name}, node {self.id}..."
+        )
         msa_aligner = MSAAlignerMAFFT
-        new_msa = msa_aligner.get_updated_alignment(leaf_name=f"{self.prg_builder.locus_name}, node {self.id}",
-                                                   previous_alignment=previous_msa_filename,
-                                                   new_sequences=list(self.new_sequences),
-                                                   temp_prefix=temp_prefix)
+        new_msa = msa_aligner.get_updated_alignment(
+            leaf_name=f"{self.prg_builder.locus_name}, node {self.id}",
+            previous_alignment=previous_msa_filename,
+            new_sequences=list(self.new_sequences),
+            temp_prefix=temp_prefix,
+        )
 
         # update the alignment
         self.alignment = load_alignment_file(str(new_msa), "fasta")
@@ -384,11 +403,13 @@ class PrgBuilderSingleClusterNode(PrgBuilderRecursiveTreeNode):
 
         # regenerate recursion tree
         self._children = self._get_children()
+
     ##################################################################################
 
 
 class LeafNotFoundException(Exception):
     pass
+
 
 class PrgBuilder(object):
     """
@@ -397,12 +418,7 @@ class PrgBuilder(object):
     """
 
     def __init__(
-        self,
-        locus_name,
-        msa_file,
-        alignment_format,
-        max_nesting,
-        min_match_length
+        self, locus_name, msa_file, alignment_format, max_nesting, min_match_length
     ):
         self.locus_name = locus_name
         self.msa_file = msa_file
@@ -413,10 +429,9 @@ class PrgBuilder(object):
         self.node_id = 0
 
         alignment = load_alignment_file(msa_file, alignment_format)
-        self._root = PrgBuilderSingleClusterNode(nesting_level=1,
-                                                 alignment=alignment,
-                                                 parent=None,
-                                                 prg_builder=self)
+        self._root = PrgBuilderSingleClusterNode(
+            nesting_level=1, alignment=alignment, parent=None, prg_builder=self
+        )
 
     def build_prg(self):
         self._site_num = 5
@@ -427,7 +442,7 @@ class PrgBuilder(object):
 
     def get_next_site_num(self):
         previous_site_num = self._site_num
-        self._site_num+=2
+        self._site_num += 2
         return previous_site_num
 
     def get_next_node_id(self):
@@ -442,7 +457,9 @@ class PrgBuilder(object):
         # TODO: move this back to assert once is solved
         interval_is_indexed = interval in self.leaves_index
         if not interval_is_indexed:
-            raise LeafNotFoundException(f"Queried interval {interval} does not exist in leaves index for locus {self.locus_name}")
+            raise LeafNotFoundException(
+                f"Queried interval {interval} does not exist in leaves index for locus {self.locus_name}"
+            )
 
         # assert interval in self.leaves_index, \
         #     f"Fatal error: Queried interval {interval} does not exist in leaves index for locus {self.locus_name}"
@@ -463,6 +480,7 @@ class PrgBuilderCollection:
     """
     Represent a collection of PrgBuilder and some other info, to be serialised and deserialised
     """
+
     def __init__(self, locus_name_to_pickle_files, cl_options):
         self.locus_name_to_pickle_files = locus_name_to_pickle_files
         self.cl_options = cl_options

--- a/make_prg/prg_encoder.py
+++ b/make_prg/prg_encoder.py
@@ -48,7 +48,8 @@ class PrgEncoder:
 
     @staticmethod
     def write(
-        encoding: List[int], ostream: BinaryIO,
+        encoding: List[int],
+        ostream: BinaryIO,
     ):
         ostream.write(b"".join(map(to_bytes, encoding)))
 

--- a/make_prg/seq_utils.py
+++ b/make_prg/seq_utils.py
@@ -1,6 +1,7 @@
 from typing import Generator, Sequence, Tuple
 import itertools
-from make_prg.utils import print_with_time
+
+from loguru import logger
 
 from make_prg.from_msa import MSA
 
@@ -78,12 +79,10 @@ def get_interval_seqs(interval_alignment: MSA):
                 expanded_seqs.append(expanded_str)
 
     if len(expanded_set) == 0:
-        print_with_time(
-            "WARNING: Every sequence must have contained an N in this slice - redo sequence curation"
+        logger.warning(
+            "Every sequence must have contained an N in this slice - redo sequence curation"
         )
-        print_with_time(f'Sequences were: {" ".join(callback_seqs)}')
-        print_with_time(
-            "Using these sequences anyway, and should be ignored downstream"
-        )
+        logger.warning(f'Sequences were: {" ".join(callback_seqs)}')
+        logger.warning("Using these sequences anyway, and should be ignored downstream")
         return callback_seqs
     return expanded_seqs

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -1,20 +1,13 @@
 from pathlib import Path
-import sys
-from datetime import datetime
 
 
 def output_files_already_exist(output_prefix):
-    return Path(output_prefix + "_prgs").exists() or \
-           Path(output_prefix + "_tmp").exists() or \
-           Path(output_prefix + ".prg.fa").exists() or \
-           Path(output_prefix + ".update_DS").exists()
-
-
-datefmt="%d/%m/%Y %H:%M:%S"
-def print_with_time(message):
-    date_time_obj = datetime.now()
-    timestamp_str = date_time_obj.strftime(datefmt)
-    print(f"{timestamp_str} {message}")
+    return (
+        Path(output_prefix + "_prgs").exists()
+        or Path(output_prefix + "_tmp").exists()
+        or Path(output_prefix + ".prg.fa").exists()
+        or Path(output_prefix + ".update_DS").exists()
+    )
 
 
 def assert_sequence_is_composed_of_ACGT_only(seq):

--- a/scripts/build_precompiled_binary/build_precompiled_binary.sh
+++ b/scripts/build_precompiled_binary/build_precompiled_binary.sh
@@ -14,7 +14,7 @@ if [ -d "${PORTABLE_EXECUTABLE_BUILD_DIR}" ]; then
   exit 1
 fi
 
-version="0.2.0"
+version="0.3.0"
 sudo docker run --rm \
   -v "$(pwd)":/make_prg \
   leandroishilima/make_prg_precompiled_binary_builder:0.0.1 \

--- a/scripts/build_precompiled_binary/requirements.txt
+++ b/scripts/build_precompiled_binary/requirements.txt
@@ -4,6 +4,7 @@ biopython==1.78
 Cython==0.29.22
 hypothesis==6.1.1
 intervaltree==3.1.0
+loguru==0.5.3
 joblib==1.0.0
 nose==1.3.7
 numpy==1.19.5

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="make_prg",
-    version="0.2.0",
+    version="0.3.0",
     packages=find_packages(),
     url="https://github.com/rmcolq/make_prg",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
         "biopython==1.78",
         "numpy==1.20.0",
         "scikit-learn==0.24.1",
-        "intervaltree==3.1.0"
+        "intervaltree==3.1.0",
+        "loguru~=0.5.3",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
### Added

- `-v,--verbose` flag to control logging
- Ability to specify the MAFFT binary [#1]

### Changed

- Logging switched to `loguru` [#7]

### Fixed

- Use the parent path of the update data structure to locate pickle objects

I also ran `black` on the project, so never mind all the changes outside the `update` files

I bumped the version, but couldn't build the binary as there is a new dependency that needs to be added to your Docker image (I've added it to the requirements.txt file in this PR).